### PR TITLE
Avoid recursive overrides

### DIFF
--- a/lua/telescope-all-recent/override.lua
+++ b/lua/telescope-all-recent/override.lua
@@ -119,9 +119,12 @@ local function override_extensions()
     local extension_table = cache.original.load_extension(name)
     for method, _ in pairs(extension_table) do
       local combi = name .. "#" .. method
-      -- back up original method and store new one
-      cache.original.extensions[combi] = extension_table[method]
-      extension_table[method] = generate_overide(combi)
+      -- override if not already
+      if cache.original.extensions[combi] == nil then
+        -- back up original method and store new one
+        cache.original.extensions[combi] = extension_table[method]
+        extension_table[method] = generate_overide(combi)
+      end
     end
     return extension_table
   end


### PR DESCRIPTION
Recursive overrides happen if the extension was already loaded when this plugin loads. This leads to overriding the extension as part of the initial batch, which is fine. However, if the extension is loaded again using the overridden `load_extension`, the original function is lost and a recursive override takes its place.

I ran into this while using https://github.com/crispgm/telescope-heading.nvim